### PR TITLE
Prettier Pin icon style

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -1,5 +1,6 @@
 .file-explorer-plus {
     &.pin-icon {
+        color: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
         margin-right: 0.2em;
         width: 16px;
         height: 16px;
@@ -33,10 +34,5 @@
         font-size: calc(var(--font-ui-medium) * 1.3);
         font-weight: var(--font-bold);
     }
-}
-
-&.lucide-pin {
-    fill: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
-    stroke: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,9 +1,12 @@
 .file-explorer-plus {
     &.pin-icon {
-        color: var(--link-color);
         margin-right: 0.2em;
-        vertical-align: calc(var(--font-text-size) * -0.3);
-        transform: scale(0.9);
+        width: 16px;
+        height: 16px;
+        align-self: center;
+        scale: .75;
+        rotate: 45deg;
+        opacity: 0.7;
     }
 
     &.filters-activated-modal {
@@ -31,3 +34,9 @@
         font-weight: var(--font-bold);
     }
 }
+
+&.lucide-pin {
+    fill: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
+    stroke: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
+}
+


### PR DESCRIPTION
# TLDR
Before / After:
![image](https://github.com/kelszo/obsidian-file-explorer-plus/assets/13370191/0f251d15-6ad5-43e2-962d-1200846809ef)
![image](https://github.com/kelszo/obsidian-file-explorer-plus/assets/13370191/4576dd40-366b-422f-a8fe-21e2b0631ed2)

# Context
I really like this plugin, but the pin icon style drove me a bit mad.

This pr is UNTESTED. I _think_ the styles are right, but I personally don't know how to test an obsidian plugin 😂
I originally did this as a css snippet:
```css
.pin-icon {
    width: 16px;
    height: 16px;
    align-self: center;
    scale: .75;
    rotate: 45deg;
    opacity: 0.7;
}

.lucide-pin {
    fill: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
    stroke: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
}
```
