### PR TITLE
feat: add inverse hide filters option

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -47,20 +47,26 @@ export function addCommands(plugin: FileExplorerPlusPlugin) {
 export function addOnTagChange(plugin: FileExplorerPlusPlugin) {
   plugin.registerEvent(
     plugin.app.metadataCache.on("changed", (path, data, cache) => {
-      const isPinned = plugin.getFileExplorer()!.fileItems[path.path].info.pinned;
-      const isHidden = plugin.getFileExplorer()!.fileItems[path.path].info.hidden;
-
-      const shouldBePinned = plugin.settings.pinFilters.tags.some((filter) => checkTagFilter(filter, path));
-      const shouldBeHidden = plugin.settings.hideFilters.tags.some((filter) => checkTagFilter(filter, path));
-
-      if (isPinned !== shouldBePinned && !shouldBeHidden) {
-        plugin.getFileExplorer()?.requestSort();
-
+     
+      const fileExplorer = plugin.getFileExplorer();
+      if (!fileExplorer || !fileExplorer.fileItems[path.path]) {
         return;
       }
 
-      if (isHidden !== shouldBeHidden) {
-        plugin.getFileExplorer()?.requestSort();
+      const isPinned = fileExplorer.fileItems[path.path].info.pinned;
+      const isHidden = fileExplorer.fileItems[path.path].info.hidden;
+      const isInverseHide = plugin.settings.hideFilters.inverse;
+
+
+      const shouldBePinned = plugin.settings.pinFilters.tags.some((filter) => checkTagFilter(filter, path));
+      const matchesHideTagFilter = plugin.settings.hideFilters.tags.some((filter) => checkTagFilter(filter, path));
+      const shouldBeHidden = isInverseHide ? !matchesHideTagFilter : matchesHideTagFilter;
+
+      if (
+        isHidden !== shouldBeHidden ||
+        (!shouldBeHidden && isPinned !== shouldBePinned)
+      ) {
+        fileExplorer.requestSort();
       }
     }),
   );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,7 @@ export interface FileExplorerPlusPluginSettings {
     tags: TagFilter[];
     paths: PathFilter[];
     frontMatter: FrontMatterFilter[];
+    inverse: boolean;
   };
 }
 
@@ -111,6 +112,7 @@ export const FILE_EXPLORER_PLUS_DEFAULT_SETTINGS: FileExplorerPlusPluginSettings
         patternType: "STRICT",
       },
     ],
+    inverse: false,
   },
 };
 
@@ -209,6 +211,23 @@ export default class FileExplorerPlusSettingTab extends PluginSettingTab {
           new PathsActivatedModal(this.plugin, "HIDE").open();
         });
       });
+
+    new Setting(this.containerEl)
+      .setName("Inverse hide filters")
+      .setDesc("Hide everything except items matching the filters.")
+      .addToggle((toggle) =>
+        toggle
+          .setTooltip(toggle ? "Inverse" : "Normal")
+          .setValue(this.plugin.settings.hideFilters.inverse)
+          .onChange((inverse) => {
+            this.plugin.settings.hideFilters.inverse = inverse;
+
+            this.plugin.saveSettings();
+
+            this.plugin.getFileExplorer()?.requestSort();
+          })
+      );
+
     this.hideTagFiltersSettings();
     this.hidePathFiltersSettings();
     this.hideFrontMatterFiltersSettings();


### PR DESCRIPTION
Closes #41 

Folders not marked as hidden are still visible in inverse mode if one of their children are marked as hidden.